### PR TITLE
Import CENs to store when POSTing via /cin

### DIFF
--- a/src/lr_cen_handler.erl
+++ b/src/lr_cen_handler.erl
@@ -15,6 +15,7 @@ handle(<<"POST">>, Req, State) ->
     {ok, JsonBin, Req2} = cowboy_req:body(Req),
     LM = leviathan_cen:decode_binary(JsonBin),
     ok = leviathan_dby:import_cens(<<"host1">>, LM),
+    ok = leviathan_store:import_cens(<<"host1">>, LM),
     {ok, Req2, State};
 handle(_, Req, State) ->
     {ok, Req2} = cowboy_req:reply(405, [{<<"content-type">>, <<"text/plain">>}],


### PR DESCRIPTION
Now leviathan_lib has its internal store that is not automatically
synchronized with the Dobby one. Thus the cens has to be imported
to both.
